### PR TITLE
Fix dependencies and description how to import idNet

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This package supports a generalized architecture for language identification (*L
 
 To load a model:
 
-	from idNet import idNet_Enrich
+	from idNet.idNet import idNet_Enrich
 	
 	lid = idNet_Enrich("Path to model file", s3_bucket)
 	did = idNet_Enrich("Path to model file", s3_bucket)

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,9 @@ setup(
 						"pandas",
 						"scipy",
 						"sklearn",
-						"keras"
-						"numba"
+						"keras",
+						"numba",
+						"tensorflow"
 						],
 	include_package_data=True,
 	long_description=read('README.md'),


### PR DESCRIPTION
Fix dependencies in setup.py
- add missing separator
- add TensorFlow as requirement (at least one Keras back-end is required to run the language identification, of course, Theano could be used instead)

Fix import in README:
- "idNet_Enrich" is defined in "idNet/idNet.py", so the the import statement should be `from idNet.idNet import ...`